### PR TITLE
add log code

### DIFF
--- a/cn/middleware.md
+++ b/cn/middleware.md
@@ -82,7 +82,7 @@
     func (m *ExampleMiddleware) Handle(next http.HandlerFunc) http.HandlerFunc {
         return func(w http.ResponseWriter, r *http.Request) {
             // TODO generate middleware implement function, delete after code implementation
-    
+            logx.Info("example middle")
             // Passthrough to next handler if need
             next(w, r)
         }


### PR DESCRIPTION
The log code is missing, which leads to the result that does not meet the expectation.